### PR TITLE
feat: enhance llm data cleaning

### DIFF
--- a/cli/commands/data.py
+++ b/cli/commands/data.py
@@ -394,12 +394,14 @@ class DataCommand(BaseCommand):
                 batch_size=batch_size,
                 workers=workers
             )
-            
+
             # 处理文件
-            result = processor.process_file(input_path, output_path)
-            
+            scored_csv = os.path.splitext(output_path)[0] + "_scored.csv"
+            result = processor.process_file(input_path, output_path, scored_csv=scored_csv)
+
             if result == 0:
                 self.logger.info(f"LLM清洗完成: {output_path}")
+                self.logger.info(f"完整打分结果: {scored_csv}")
             else:
                 self.logger.error("LLM清洗失败")
                 # 失败时回退到raw方法

--- a/readme.md
+++ b/readme.md
@@ -66,9 +66,3 @@ Github:[@qqqqqf-q](https://github.com/qqqqqf-q)
 * 已经被重构的部分没有增加双语支持
 * todo1.增加serverapi为webui做准备
 * 代码未优化
-
-### llm clean todos
-* ctrlc自动保存
-* 自动backup
-* 实时写入
-* 再写一份ai已经打完分的完整csv


### PR DESCRIPTION
## Summary
- add backup and incremental saving to LLM data cleaner
- stream LLM-scored results to JSONL and separate CSV
- remove obsolete llm clean TODOs from readme

## Testing
- `python -m py_compile process_data/generate_chatml_llm.py cli/commands/data.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75f0a3f8c8327b664116f2b0b0300