### PR TITLE
feat: support resuming llm data clean

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -176,6 +176,7 @@ def create_parser() -> argparse.ArgumentParser:
                                help='可接受的最低分数阈值(1-5分，仅用于scoring策略，默认2分)')
     data_clean_llm.add_argument('--batch-size', type=int, help='批处理大小（默认从配置读取）')
     data_clean_llm.add_argument('--workers', type=int, help='工作进程数（默认从配置读取）')
+    data_clean_llm.add_argument('--resume', action='store_true', help='从上次中断的位置继续')
     
     # data convert
     data_convert = data_subparsers.add_parser('convert', help='转换数据格式')

--- a/cli/commands/data.py
+++ b/cli/commands/data.py
@@ -346,6 +346,7 @@ class DataCommand(BaseCommand):
             output_path = getattr(args, 'output', None) or self.config.get('data_path', './dataset/sft.jsonl')
             batch_size = getattr(args, 'batch_size', None) or self.config.get('clean_batch_size', 10)
             workers = getattr(args, 'workers', None) or self.config.get('clean_workers', 4)
+            resume = getattr(args, 'resume', False)
             
             self.logger.info(f"输入路径: {input_path}")
             self.logger.info(f"输出路径: {output_path}")
@@ -362,7 +363,7 @@ class DataCommand(BaseCommand):
                 # 获取LLM清洗策略参数
                 parser = getattr(args, 'parser', None) or self.config.get('llm_parser', 'scoring')
                 accept_score = getattr(args, 'accept_score', None) or self.config.get('accept_score', 2)
-                result = self._clean_data_llm(input_path, output_path, batch_size, workers, parser, accept_score)
+                result = self._clean_data_llm(input_path, output_path, batch_size, workers, parser, accept_score, resume)
             else:  # raw
                 result = self._clean_data_raw(input_path, output_path)
             
@@ -376,7 +377,7 @@ class DataCommand(BaseCommand):
         except Exception as e:
             raise DataProcessingError(f"数据清洗失败: {e}")
     
-    def _clean_data_llm(self, input_path: str, output_path: str, batch_size: int, workers: int, parser: str = 'scoring', accept_score: int = 2) -> int:
+    def _clean_data_llm(self, input_path: str, output_path: str, batch_size: int, workers: int, parser: str = 'scoring', accept_score: int = 2, resume: bool = False) -> int:
         """使用LLM清洗数据"""
         try:
             from process_data.generate_chatml_llm import LLMDataProcessor
@@ -386,6 +387,8 @@ class DataCommand(BaseCommand):
                 self.logger.info(f"分数阈值: {accept_score}")
                 self.logger.info(f"批处理大小: {batch_size}")
                 self.logger.info(f"工作线程数: {workers}")
+            if resume:
+                self.logger.info("启用断点续处理")
             
             # 创建LLM数据处理器
             processor = LLMDataProcessor(
@@ -394,12 +397,14 @@ class DataCommand(BaseCommand):
                 batch_size=batch_size,
                 workers=workers
             )
-            
+
             # 处理文件
-            result = processor.process_file(input_path, output_path)
-            
+            scored_csv = os.path.splitext(output_path)[0] + "_scored.csv"
+            result = processor.process_file(input_path, output_path, scored_csv=scored_csv, resume=resume)
+
             if result == 0:
                 self.logger.info(f"LLM清洗完成: {output_path}")
+                self.logger.info(f"完整打分结果: {scored_csv}")
             else:
                 self.logger.error("LLM清洗失败")
                 # 失败时回退到raw方法

--- a/docs/en/guide/clean-data.md
+++ b/docs/en/guide/clean-data.md
@@ -56,6 +56,19 @@ python generate_training_data_llm.py
 ```
 > If you encounter 400 error, it's most likely because the message is too large and was rejected by the model framework
 
+## Command Options
+
+```bash
+python cli.py data clean llm
+
+# Other parameters
+--input   Input CSV directory (default from config)
+--output  Output file path (default from config)
+--batch-size  Batch size (default from config)
+--workers Work processes (default from config)
+--resume  Continue from last scored ID
+```
+
 ---
 
 ## vLLM Setup

--- a/docs/guide/clean-data.md
+++ b/docs/guide/clean-data.md
@@ -60,8 +60,9 @@ python cli.py data clean llm --parser segment
 --output - 输出文件路径（默认从配置读取）
 --batch-size - 批处理大小（默认从配置读取）
 --workers - 工作进程数（默认从配置读取）
+--resume - 从上一次的评分结果继续处理
 ```
-> 可以调大`betch_size`来减少api调用次数以减少tpm/rpm限制  
+> 可以调大`betch_size`来减少api调用次数以减少tpm/rpm限制
 > 不过会增大token  
 
 > 如果遇到了400报错大概率是因为message太大了被模型框架拒绝了

--- a/process_data/generate_chatml_llm.py
+++ b/process_data/generate_chatml_llm.py
@@ -11,6 +11,9 @@ import logging
 import argparse
 import re
 import sys
+import shutil
+import csv
+from datetime import datetime
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -72,54 +75,56 @@ class LLMScoringStrategy:
         self.batch_size = batch_size
         self.workers = workers
         
-    def judge(self, qa_pairs: List[QaPair]) -> None:
+    def judge(self, qa_pairs: List[QaPair], on_batch_scored=None) -> None:
         """
         对问答对进行LLM打分
-        
+
         Args:
             qa_pairs: 问答对列表，会直接修改其score属性
+            on_batch_scored: 每个批次打分完成后的回调函数
         """
         logger.info(f"开始LLM打分，共{len(qa_pairs)}个问答对")
-        
+
         # 构建打分提示词
         scoring_prompt = self._build_scoring_prompt()
-        
+
         # 批量处理配置
         clean_set_args = config.get('clean_set_args', {})
         openai_api = clean_set_args.get('openai_api', {})
         batch_size = self.batch_size if self.batch_size is not None else openai_api.get('clean_batch_size', 10)
         workers = self.workers if self.workers is not None else openai_api.get('clean_workers', 4)
-        
+
         logger.info(f"实际使用批处理大小: {batch_size}")
         logger.info(f"实际使用工作线程数: {workers}")
-        
+
         # 分批处理
         batches = []
         for i in range(0, len(qa_pairs), batch_size):
             batches.append(qa_pairs[i:i + batch_size])
-        
+
         # 多线程处理批次
         with ThreadPoolExecutor(max_workers=workers) as executor:
             # 提交所有任务
             future_to_batch = {
-                executor.submit(self._score_batch, batch, scoring_prompt): batch 
+                executor.submit(self._score_batch, batch, scoring_prompt): batch
                 for batch in batches
             }
-            
+
             # 使用tqdm显示进度
             with tqdm(total=len(batches), desc="LLM打分进度") as pbar:
                 for future in as_completed(future_to_batch):
+                    batch = future_to_batch[future]
                     try:
                         future.result()  # 获取结果，如果有异常会抛出
                     except Exception as e:
-                        batch = future_to_batch[future]
                         logger.error(f"批次处理失败: {e}")
                         # 给失败的批次默认分数
                         for qa in batch:
                             if qa.score is None:
                                 qa.score = 0
-                    finally:
-                        pbar.update(1)
+                    if on_batch_scored:
+                        on_batch_scored(batch)
+                    pbar.update(1)
     
     def _build_scoring_prompt(self) -> str:
         """构建LLM打分提示词"""
@@ -407,15 +412,16 @@ class LLMDataProcessor:
         else:
             raise ValueError(f"不支持的处理策略: {parser}")
     
-    def process_file(self, input_path: str, output_path: str, **kwargs) -> int:
+    def process_file(self, input_path: str, output_path: str, resume: bool = False, **kwargs) -> int:
         """
         处理文件
-        
+
         Args:
             input_path: 输入文件路径
             output_path: 输出文件路径
+            resume: 是否从上次中断位置继续
             **kwargs: 其他参数
-            
+
         Returns:
             处理结果状态码
         """
@@ -427,7 +433,7 @@ class LLMDataProcessor:
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             
             if self.parser == 'scoring':
-                return self._process_with_scoring(input_path, output_path, **kwargs)
+                return self._process_with_scoring(input_path, output_path, resume=resume, **kwargs)
             elif self.parser == 'segment':
                 return self._process_with_segment(input_path, output_path, **kwargs)
             
@@ -435,38 +441,125 @@ class LLMDataProcessor:
             logger.error(f"文件处理失败: {e}")
             return 1
     
-    def _process_with_scoring(self, input_path: str, output_path: str, **kwargs) -> int:
+    def _backup_file(self, path: str) -> None:
+        """备份已有文件"""
+        if path and os.path.exists(path):
+            backup_path = f"{path}.{datetime.now().strftime('%Y%m%d%H%M%S')}.bak"
+            shutil.copy(path, backup_path)
+            logger.info(f"已备份文件: {backup_path}")
+
+    def _append_qa_pair(self, fp, qa: QaPair) -> None:
+        """追加单个问答对到JSONL文件"""
+        messages = []
+        system_prompt = getattr(self, 'system_prompt', None)
+        if system_prompt and system_prompt.strip() and system_prompt != "*":
+            messages.append({"role": "system", "content": system_prompt})
+        processed_messages = self._process_messages(qa.messages)
+        messages.extend({"role": msg.role, "content": msg.content} for msg in processed_messages)
+        data = {'messages': messages}
+        if qa.images:
+            data['images'] = qa.images
+        fp.write(json.dumps(data, ensure_ascii=False) + '\n')
+
+    def _get_last_scored_id(self, scored_csv: str) -> Optional[str]:
+        """读取已评分CSV中的最后一个ID"""
+        last_id = None
+        try:
+            with open(scored_csv, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    last_id = row.get('id')
+        except Exception as e:
+            logger.warning(f"读取已评分文件失败: {e}")
+        return last_id
+
+    def _process_with_scoring(self, input_path: str, output_path: str, scored_csv: Optional[str] = None, resume: bool = False, **kwargs) -> int:
         """
         使用打分策略处理
-        
+
         Args:
             input_path: 输入文件路径
             output_path: 输出文件路径
+            scored_csv: 完整打分结果CSV路径
+            resume: 是否从已评分位置继续
             **kwargs: 其他参数
-            
+
         Returns:
             处理结果状态码
         """
         try:
-            # 读取输入数据
             qa_pairs = self._load_qa_pairs(input_path)
-            
+
             if not qa_pairs:
                 logger.warning("没有找到有效的问答对")
                 return 1
-            
-            # LLM打分
-            self.strategy.judge(qa_pairs)
-            
-            # 根据分数过滤
-            filtered_pairs = self.strategy.filter_by_score(qa_pairs)
-            
-            # 保存结果
-            self._save_qa_pairs(filtered_pairs, output_path)
-            
+
+            start_index = 0
+            if resume and scored_csv and os.path.exists(scored_csv):
+                last_id = self._get_last_scored_id(scored_csv)
+                if last_id:
+                    for idx, qa in enumerate(qa_pairs):
+                        if qa.id == last_id:
+                            start_index = idx + 1
+                            logger.info(f"从已评分ID {last_id} 的下一条继续")
+                            break
+
+            qa_pairs_to_process = qa_pairs[start_index:]
+
+            # 备份已有输出文件
+            self._backup_file(output_path)
+            if scored_csv:
+                self._backup_file(scored_csv)
+
+            # 打开输出文件
+            out_fp = open(output_path, 'a' if resume and os.path.exists(output_path) else 'w', encoding='utf-8')
+            csv_fp = None
+            csv_writer = None
+            if scored_csv:
+                csv_exists = os.path.exists(scored_csv)
+                csv_fp = open(scored_csv, 'a' if resume else 'w', newline='', encoding='utf-8')
+                csv_writer = csv.DictWriter(csv_fp, fieldnames=['id', 'Q', 'A', 'score'])
+                if not (resume and csv_exists and os.path.getsize(scored_csv) > 0):
+                    csv_writer.writeheader()
+
+            total = len(qa_pairs_to_process)
+            accepted = 0
+
+            def handle_batch(batch: List[QaPair]):
+                nonlocal accepted
+                for qa in batch:
+                    user = next((m.content for m in qa.messages if m.role == 'user'), '')
+                    assistant = next((m.content for m in qa.messages if m.role == 'assistant'), '')
+                    if csv_writer:
+                        csv_writer.writerow({'id': qa.id, 'Q': user, 'A': assistant, 'score': qa.score})
+                    if qa.score is not None and qa.score >= self.strategy.accept_score:
+                        self._append_qa_pair(out_fp, qa)
+                        accepted += 1
+                out_fp.flush()
+                if csv_fp:
+                    csv_fp.flush()
+
+            try:
+                self.strategy.judge(qa_pairs_to_process, on_batch_scored=handle_batch)
+            except KeyboardInterrupt:
+                logger.warning("检测到中断，已保存当前进度")
+            finally:
+                out_fp.close()
+                if csv_fp:
+                    csv_fp.close()
+
+            # 分数统计
+            scores = [qa.score for qa in qa_pairs_to_process if qa.score is not None]
+            if scores:
+                score_series = pd.Series(scores)
+                score_counts = score_series.value_counts().sort_index()
+                logger.info(f"分数分布: {dict(score_counts)}")
+            logger.info(f"LLM打分过滤完成: {accepted}/{total} 个问答对通过筛选")
             logger.info(f"打分策略处理完成: {output_path}")
+            if scored_csv:
+                logger.info(f"完整打分结果已保存: {scored_csv}")
             return 0
-            
+
         except Exception as e:
             logger.error(f"打分策略处理失败: {e}")
             return 1

--- a/readme.md
+++ b/readme.md
@@ -66,9 +66,3 @@ Github:[@qqqqqf-q](https://github.com/qqqqqf-q)
 * 已经被重构的部分没有增加双语支持
 * todo1.增加serverapi为webui做准备
 * 代码未优化
-
-### llm clean todos
-* ctrlc自动保存
-* 自动backup
-* 实时写入
-* 再写一份ai已经打完分的完整csv


### PR DESCRIPTION
## Summary
- allow LLM data cleaner to resume from last scored item and append results
- add `--resume` flag to `qds data clean llm`
- document resume option in data cleaning guides

## Testing
- `python -m py_compile process_data/generate_chatml_llm.py cli/commands/data.py cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75f0a3f8c8327b664116f2b0b0300