### PR TITLE
feat: 支持llm清洗断点继续

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -176,6 +176,7 @@ def create_parser() -> argparse.ArgumentParser:
                                help='可接受的最低分数阈值(1-5分，仅用于scoring策略，默认2分)')
     data_clean_llm.add_argument('--batch-size', type=int, help='批处理大小（默认从配置读取）')
     data_clean_llm.add_argument('--workers', type=int, help='工作进程数（默认从配置读取）')
+    data_clean_llm.add_argument('--resume', action='store_true', help='从上次中断处继续')
     
     # data convert
     data_convert = data_subparsers.add_parser('convert', help='转换数据格式')

--- a/docs/guide/clean-data.md
+++ b/docs/guide/clean-data.md
@@ -55,11 +55,15 @@ python cli.py data clean llm --parser scoring --accept-score 4
 # 使用句段策略(没写完)
 python cli.py data clean llm --parser segment
 
+# 断点继续
+python cli.py data clean llm --resume
+
 # 其他参数
 --input - 输入CSV目录路径（默认从配置读取）
 --output - 输出文件路径（默认从配置读取）
 --batch-size - 批处理大小（默认从配置读取）
 --workers - 工作进程数（默认从配置读取）
+--resume - 从上次中断处继续
 ```
 > 可以调大`betch_size`来减少api调用次数以减少tpm/rpm限制  
 > 不过会增大token  


### PR DESCRIPTION
## Summary
- add resume flag for llm data cleaning cli
- allow processor to continue from last scored id
- document llm cleaning resume option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b76af777848327883eba4b0bf422a4